### PR TITLE
Programme visual hint

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -13,6 +13,7 @@
     'chevronLeft': '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"> <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" /> </svg>',
     'chevronRight': '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"> <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" /> </svg>',
     'chevronUp': '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"> <path fill-rule="evenodd" d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z" clip-rule="evenodd" /> </svg>',
+    'info': '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" /> </svg>',
     'menu': '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"> <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" /> </svg>',
   };
 </script>

--- a/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
+++ b/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
@@ -116,7 +116,7 @@
   {:else}
     {#if mainHtml && mainHtml.length}
       {#if isProgram}
-        <div class="Event__alert | m-2 rounded inline-block bg-neutral-200 text-neutral-700 p-3">
+        <div class="Event__alert | mb-2 bg-neutral-200 text-neutral-700 p-3">
           <div class="content text-sm">
             <span class="inline-block align-top text-neutral-500 mr-1">
               <Icon name="info" size={20} />

--- a/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
+++ b/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
@@ -116,12 +116,12 @@
   {:else}
     {#if mainHtml && mainHtml.length}
       {#if isProgram}
-        <div class="Event__alert | mb-2 bg-neutral-200 text-neutral-700 p-3">
-          <div class="content text-sm">
-            <span class="inline-block align-top text-neutral-500 mr-1">
-              <Icon name="info" size={20} />
-            </span>
+        <div class="Event__alert | m-3 rounded inline-block bg-neutral-200 flex flex-row text-neutral-700 p-3">
+          <span class="inline-block align-top text-neutral-500 mr-2">
+            <Icon name="info" size={20} />
+          </span>
 
+          <div class="content text-sm">
             Note&nbsp;: cette page affiche actuellement le <strong>programme</strong> de l’épreuve.
           </div>
         </div>

--- a/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
+++ b/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
@@ -116,7 +116,7 @@
   {:else}
     {#if mainHtml && mainHtml.length}
       {#if isProgram}
-        <div class="Event__alert | m-3 rounded inline-block bg-neutral-200 flex flex-row text-neutral-700 p-3">
+        <div class="Event__alert | mb-2 bg-neutral-200 flex flex-row text-neutral-700 p-3">
           <span class="inline-block align-top text-neutral-500 mr-2">
             <Icon name="info" size={20} />
           </span>

--- a/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
+++ b/src/routes/meets/[meetId]/hytek/event/[eventId].svelte
@@ -116,10 +116,13 @@
   {:else}
     {#if mainHtml && mainHtml.length}
       {#if isProgram}
-        <div class="Event__alert | my-6 bg-neutral-200 text-neutral-800 p-4 rounded">
-          <Icon name="info" />
-          <div class="content">
-            Cette page affiche la liste préliminaire (et non les résultats).
+        <div class="Event__alert | m-2 rounded inline-block bg-neutral-200 text-neutral-700 p-3">
+          <div class="content text-sm">
+            <span class="inline-block align-top text-neutral-500 mr-1">
+              <Icon name="info" size={20} />
+            </span>
+
+            Note&nbsp;: cette page affiche actuellement le <strong>programme</strong> de l’épreuve.
           </div>
         </div>
       {/if}


### PR DESCRIPTION
Ajout d’une note dans l’en-tête pour rendre graphiquement évident qu’il s’agit d’une liste provisoire (Meet Program ou Performance List) et non des résultats.

2 options envisagées:

**A) bandeau pleine largeur**

![bandeau](https://user-images.githubusercontent.com/9596476/181264984-d1c121bd-f59c-4c66-a240-562f57f8dbd3.png)

**B) Bulle**

![bulle](https://user-images.githubusercontent.com/9596476/181265015-c8e19d18-b517-4b40-92b0-8356006da728.png)
