### PR TITLE
add 'color-scheme' meta tag to avoid tampering w/ colors

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,7 @@
 		<meta name="description" content="" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
 		%sveltekit.head%
 	</head>
 	<body>


### PR DESCRIPTION
samsung’s internet browser applies dark mode transformations by default